### PR TITLE
Make the extension available for firefox users

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Additional settings allow for choosing which mouse button should do the work, wh
 and styles, and other minor tweaks. 
 
 ### Where to Get It
-It is published on the [Chrome Web Store](https://chromewebstore.google.com/detail/jaccokbdifidliancbiinoccfpilkiea/)
+It is published on the [Chrome Web Store](https://chromewebstore.google.com/detail/jaccokbdifidliancbiinoccfpilkiea/) and on the [Firefox Extensions site](https://addons.mozilla.org/en-US/firefox/addon/spacebar-drag/)
 
 #### Bugs
 Please report bugs and issues here. This is a passive project for fun, so most requests will be second priority to my income generating

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This is a quickly built extension for Chrome, Brave, Edge, and other chrome extension supporting browsers. 
+This is a quickly built extension for chrome and firefox extension supporting browsers. 
 
 ### Why This?
 Several times now I've found myself wishing I had another way to navigate large images and media in my web 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-This is a quickly built extension for chrome and firefox extension supporting browsers. 
+This is a quickly built extension for browsers that support chrome and firefox extensions, e.g.:
+Chrome, Vivaldi, Brave, Firefox, Librewolf, Zen
 
 ### Why This?
 Several times now I've found myself wishing I had another way to navigate large images and media in my web 

--- a/content.js
+++ b/content.js
@@ -16,14 +16,14 @@
   let friction = 0.9;
 
   // listen for changes to the options
-  chrome.storage.onChanged.addListener((changes, area) => {
+  browser.storage.onChanged.addListener((changes, area) => {
     if (area === "sync" && changes.options?.newValue) {
       updateVariablesFromData(changes.options.newValue);
     }
   });
 
   // default load data
-  chrome.storage.sync.get("options", (data) =>
+  browser.storage.sync.get("options", (data) =>
     updateVariablesFromData(data.options)
   );
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,23 +1,30 @@
 {
-    "manifest_version": 3,
-    "name": "Spacebar Drag",
-    "version": "1.1",
-    "description": "Use spacebar to scroll the window around with precision.",
-    "permissions": ["storage"],
-    "content_scripts": [
-      {
-        "matches": ["<all_urls>"],
-        "js": ["content.js"]
+  "manifest_version": 3,
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "@spacebar-drag",
+      "data_collection_permissions": {
+        "required": ["none"]
       }
-    ],
-    "action": {
-      "default_popup": "popup.html",
-      "default_icon": "images/icon_512.png"
-    },
-    "icons": {
-      "16": "images/icon_16.png",
-      "48": "images/icon_48.png",
-      "128": "images/icon_128.png"
     }
+  },
+  "name": "Spacebar Drag",
+  "version": "1.2",
+  "description": "Use spacebar to scroll the window around with precision.",
+  "permissions": ["storage"],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"]
+    }
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_icon": "images/icon_512.png"
+  },
+  "icons": {
+    "16": "images/icon_16.png",
+    "48": "images/icon_48.png",
+    "128": "images/icon_128.png"
   }
-  
+}

--- a/popup.js
+++ b/popup.js
@@ -3,12 +3,12 @@ const optionsForm = document.getElementById("settingsForm");
 
 optionsForm.activeBorder.addEventListener("change", (event) => {
   options.activeBorder = event.target.value;
-  chrome.storage.sync.set({ options });
+  browser.storage.sync.set({ options });
 });
 
 optionsForm.activeBorderThickness.addEventListener("change", (event) => {
   options.activeBorderThickness = parseInt(event.target.value);
-  chrome.storage.sync.set({ options });
+  browser.storage.sync.set({ options });
 });
 
 optionsForm.activeBorderThickness.addEventListener("input", (event) => {
@@ -18,12 +18,12 @@ optionsForm.activeBorderThickness.addEventListener("input", (event) => {
 
 optionsForm.activeBackgroundColor.addEventListener("change", (event) => {
   options.activeBackgroundColor = event.target.value;
-  chrome.storage.sync.set({ options });
+  browser.storage.sync.set({ options });
 });
 
 optionsForm.activeBackgroundOpacity.addEventListener("change", (event) => {
   options.activeBackgroundOpacity = parseFloat(event.target.value);
-  chrome.storage.sync.set({ options });
+  browser.storage.sync.set({ options });
 });
 
 optionsForm.activeBackgroundOpacity.addEventListener("input", (event) => {
@@ -33,25 +33,25 @@ optionsForm.activeBackgroundOpacity.addEventListener("input", (event) => {
 
 optionsForm.invertScroll.addEventListener("change", (event) => {
   options.invertScroll = event.target.checked;
-  chrome.storage.sync.set({ options });
+  browser.storage.sync.set({ options });
 });
 
 optionsForm.displayToolTip.addEventListener("change", (event) => {
   options.displayToolTip = event.target.checked;
-  chrome.storage.sync.set({ options });
+  browser.storage.sync.set({ options });
 });
 
 // add useVelocities checkbox
 optionsForm.useVelocities.addEventListener("change", (event) => {
   options.useVelocities = event.target.checked;
   optionsForm.velocityFriction.disabled = !event.target.checked;
-  chrome.storage.sync.set({ options });
+  browser.storage.sync.set({ options });
 });
 
 // add velocityFriction input
 optionsForm.velocityFriction.addEventListener("change", (event) => {
   options.velocityFriction = parseFloat(event.target.value);
-  chrome.storage.sync.set({ options });
+  browser.storage.sync.set({ options });
 });
 
 optionsForm.velocityFriction.addEventListener("input", (event) => {
@@ -63,7 +63,7 @@ optionsForm.velocityFriction.addEventListener("input", (event) => {
 // add activatedMouseButton input
 optionsForm.activatedMouseButton.addEventListener("change", (event) => {
   options.activatedMouseButton = parseInt(event.target.value);
-  chrome.storage.sync.set({ options });
+  browser.storage.sync.set({ options });
 });
 
 optionsForm.closeBtn.addEventListener("click", () => {
@@ -71,7 +71,7 @@ optionsForm.closeBtn.addEventListener("click", () => {
 });
 
 // inital data load
-chrome.storage.sync.get("options", (data) => {
+browser.storage.sync.get("options", (data) => {
   // get any data currently stored for this extension
   Object.assign(options, data.options);
   options.activeBorder = options.activeBorder || "#008CFF";
@@ -93,7 +93,7 @@ chrome.storage.sync.get("options", (data) => {
   }
 
   // sync anything we may have set defaults for
-  chrome.storage.sync.set({ options });
+  browser.storage.sync.set({ options });
 
   optionsForm.activeBorder.value = options.activeBorder;
   optionsForm.activeBorderThickness.value = options.activeBorderThickness;


### PR DESCRIPTION
I wanted to rewrite the plugin for firefox, but your code is just so good, that I would've copied 99% of it.

The only changes needed for firefox were:
1. Replace `chrome.storage` with `browser.storage`
2. Add firefox-specific data to the manifest.json
3. Update the readme

For now I published it on the firefox addons site, I hope that's no problem?
Iif you don't like this, I'll take it down in an instant of course! 
But I thought you'd rather not be responsible for yet another extension store and saw your email too late...